### PR TITLE
Github CI: add frontend tests and run int-tests in a temporary directory

### DIFF
--- a/generators/app/templates/.github/workflows/github-ci.yml.ejs
+++ b/generators/app/templates/.github/workflows/github-ci.yml.ejs
@@ -34,12 +34,16 @@ jobs:
               run: npm install -g yo
             - name: Install JHipster
               run: npm install -g generator-jhipster
+            - name: Prepare temporary directory
+              run: |
+                cp -r ./test-integration/samples/${{ matrix.sample }} /tmp/
+                cp -r ./test-integration/samples/.jhipster /tmp/${{ matrix.sample }}
             - name: Generate project
               run: |
                 jhipster --with-entities --no-insight
                 yo jhipster-<%= moduleName %> default --force
-              working-directory: ./test/templates/${{ matrix.sample }}
-            - name: Run integration-tests
+              working-directory: /tmp/${{ matrix.sample }}
+            - name: Run backend tests
               run: |
                   if [ -f "mvnw" ]; then
                       ./mvnw -ntp -P-webpack verify --batch-mode \
@@ -64,4 +68,17 @@ jobs:
                           -Dlogging.level.org.springframework.web=OFF \
                           -Dlogging.level.org.springframework.security=OFF
                   fi
-              working-directory: ./test/templates/${{ matrix.sample }}
+              working-directory: /tmp/${{ matrix.sample }}
+            - name: Run frontend tests
+              run: |
+                  if [[ $(grep yarn .yo-rc.json) != "" ]]; then
+                    JHI_CLIENT_PACKAGE_MANAGER=yarn
+                  else
+                    JHI_CLIENT_PACKAGE_MANAGER=npm
+                  fi
+                  if [ -f "tsconfig.json" ]; then
+                    $JHI_CLIENT_PACKAGE_MANAGER run test
+                  fi
+              working-directory: /tmp/${{ matrix.sample }}
+
+


### PR DESCRIPTION
Running integration tests in a temporary directory is required since there are some side effects (e.g. parent eslint configuration) when running in a subdirectory of generator-jhipster-module