### PR TITLE
fix: add jhipster-5 tag to add the module in marketplace list

### DIFF
--- a/generators/app/templates/package.json.ejs
+++ b/generators/app/templates/package.json.ejs
@@ -5,6 +5,7 @@
   "keywords": [
     "yeoman-generator",
     "jhipster-module",
+    "jhipster-5",
     "jhipster-6"
   ],
   "homepage": "https://github.com/<%= githubName %>/generator-jhipster-<%= moduleName %>",


### PR DESCRIPTION
New generated modules with generator-jhipster-module are only tagged "jhipster-6" so they don't appear in the markerplace list in `prompts.js` of the main generator :

```
function askModulesToBeInstalled(done, generator) {
    generator.httpsGet(
        'https://api.npms.io/v2/search?q=keywords:jhipster-module+jhipster-5&from=0&size=50',
        body => {
```

A fix should be created as well in the main generator to fix the npm URL where the "jhipster-5" tag is searched but this a quick win fix for the next modules to be generated.